### PR TITLE
docs: Fix broken Astro link

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 
 - [Vue Single-File Components](https://vuejs.org/guide/scaling-up/sfc.html)
 - [Svelte Components](https://svelte.dev/docs#component-format)
-- [Astro Components](https://docs.astro.build/core-concepts/astro-components/)
+- [Astro Components](https://docs.astro.build/en/core-concepts/astro-components/)
 - [PHP](http://php.net)
 - [Quick App](https://doc.quickapp.cn/framework/source-file.html)
 - [XSLT](https://www.w3.org/TR/xslt-30/)


### PR DESCRIPTION
Hello, I noticed the link to the docs about Astro Components on the README was going to a 404 page.

Looks like the URL changed a bit when they added i18n to the site, so the link is now `docs.astro.build/en/core-concepts/astro-components/`  instead of `docs.astro.build/core-concepts/astro-components/`.