### PR TITLE
WXML inline style support

### DIFF
--- a/lib/html/extract-styles.js
+++ b/lib/html/extract-styles.js
@@ -5,9 +5,13 @@ const buildSyntaxResolver = require("../syntax/build-syntax-resolver");
 const buildTemplateSyntax = require("../template/syntax");
 const JsxLikeTokenizer = require("./jsx-like-tokenizer");
 const AstroTokenizer = require("./astro-tokenizer");
+const WxmlTokenizer = require("./wxml-tokenizer");
 const { cssSafeSyntax } = require("../syntax/syntaxes");
 
-function iterateCode(source, { onStyleTag, onStyleAttribute, svelte, astro }) {
+function iterateCode(
+	source,
+	{ onStyleTag, onStyleAttribute, svelte, astro, wxml },
+) {
 	const openTag = {};
 	let disable, ignore, style;
 
@@ -94,7 +98,13 @@ function iterateCode(source, { onStyleTag, onStyleAttribute, svelte, astro }) {
 			},
 		},
 		{
-			Tokenizer: svelte ? JsxLikeTokenizer : astro ? AstroTokenizer : undefined,
+			Tokenizer: svelte
+				? JsxLikeTokenizer
+				: astro
+					? AstroTokenizer
+					: wxml
+						? WxmlTokenizer
+						: undefined,
 		},
 	);
 
@@ -129,6 +139,7 @@ function extractStyles(source, opts) {
 		);
 	const svelte = opts.from && /\.svelte$/i.test(opts.from);
 	const astro = opts.from && /\.astro$/i.test(opts.from);
+	const wxml = opts.from && /\.wxml$/i.test(opts.from);
 
 	function onStyleTag(style) {
 		if (
@@ -145,6 +156,9 @@ function extractStyles(source, opts) {
 	}
 
 	function onStyleAttribute(style) {
+		if (wxml && /^\s*\{\{[\s\S]*\}\}\s*$/.test(style.content)) {
+			return;
+		}
 		if (/\{[\s\S]*?\}/.test(style.content)) {
 			style.syntax = buildTemplateSyntax(
 				resolveSyntax("css", {
@@ -164,6 +178,7 @@ function extractStyles(source, opts) {
 		onStyleAttribute,
 		svelte,
 		astro,
+		wxml,
 	});
 
 	return styles;

--- a/lib/html/wxml-tokenizer.js
+++ b/lib/html/wxml-tokenizer.js
@@ -1,0 +1,69 @@
+"use strict";
+
+const { Tokenizer } = require("htmlparser2");
+
+const STATE_IN_TAG_NAME = 3; // State.InTagName
+const STATE_SPECIAL_START_SEQUENCE = 23; // State.SpecialStartSequence
+const CHAR_W = "w".charCodeAt(0);
+const CHAR_X = "x".charCodeAt(0);
+const CHAR_S = "s".charCodeAt(0);
+
+// </wxs
+const WXS_END_SEQUENCE = new Uint8Array([
+	"<".charCodeAt(0),
+	"/".charCodeAt(0),
+	CHAR_W,
+	CHAR_X,
+	CHAR_S,
+]);
+
+function isTagBoundary(charCode) {
+	return (
+		charCode == null ||
+		charCode === "/".charCodeAt(0) || // /
+		charCode === ">".charCodeAt(0) || // >
+		charCode === " ".charCodeAt(0) || // space
+		charCode === "\t".charCodeAt(0) || // tab
+		charCode === "\n".charCodeAt(0) || // \n
+		charCode === "\r".charCodeAt(0) || // \r
+		charCode === "\f".charCodeAt(0) // \f
+	);
+}
+
+/** Lowercase ASCII letter char-code for case-insensitive tag checks. */
+function lowerCase(code) {
+	return code | 0x20;
+}
+
+module.exports = class WxmlTokenizer extends Tokenizer {
+	stateBeforeTagName(c) {
+		const w = lowerCase(c);
+		const x = lowerCase(this.buffer.charCodeAt(this.index + 1));
+		const s = lowerCase(this.buffer.charCodeAt(this.index + 2));
+		const boundary = this.buffer.charCodeAt(this.index + 3);
+
+		// If we are entering a <wxs ...> tag, switch to htmlparser2's "special/raw-text" mode
+		// (similar to <script>): treat everything inside as plain text until </wxs>,
+		// so style-like text in JS code won't be parsed as real HTML attributes/tags.
+		if (
+			w === CHAR_W &&
+			x === CHAR_X &&
+			s === CHAR_S &&
+			isTagBoundary(boundary)
+		) {
+			this.sectionStart = this.index;
+			this.isSpecial = true;
+			this.currentSequence = WXS_END_SEQUENCE;
+			this.sequenceIndex = 3;
+			this.state = STATE_SPECIAL_START_SEQUENCE;
+			return;
+		}
+
+		super.stateBeforeTagName(c);
+	}
+
+	stateInTagName(c) {
+		this.state = STATE_IN_TAG_NAME;
+		super.stateInTagName(c);
+	}
+};

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "sass",
     "scss",
     "sss",
-    "sugarss"
+    "sugarss",
+    "wxml"
   ],
   "author": "gucong",
   "contributors": [

--- a/test-fixtures/ast/test.wxml
+++ b/test-fixtures/ast/test.wxml
@@ -1,0 +1,15 @@
+<wxs src="./foo.wxs"></wxs>
+<wxs module="bar">
+  var x = 1
+  module.exports = { x: x }
+</wxs>
+<wxs module="baz">
+  var style = "color: red"
+  var tpl = '<view style="color: blue;"></view>'
+</wxs>
+<view>
+  <text style="font-size: 10rpx; color: red;"></text>
+  <view style="{{ style }}"></view>
+  <view style="font-size: 10rpx; color: {{ color }};"></view>
+  <view style="font-weight: bold; font-size: {{ fontSize }}rpx; color: {{ color }}; background-image: url('{{ backgroundColor }}');"></view>
+</view>

--- a/test-fixtures/integration/stylelint/test.wxml
+++ b/test-fixtures/integration/stylelint/test.wxml
@@ -1,0 +1,9 @@
+<wxs module="foo">
+  var style = "color: red"
+  var tpl = '<view style="color: blue;"></view>'
+</wxs>
+<view>
+  <text style="font-size: 10rpx; color: red;"></text>
+  <view style="{{ style }}"></view>
+  <view style="font-size: 10rpx; color: {{ color }};"></view>
+</view>

--- a/test/__snapshots__/ast.js.snap
+++ b/test/__snapshots__/ast.js.snap
@@ -2346,6 +2346,328 @@ const buttonPointerEvents = computed(() =>
 }
 `;
 
+exports[`AST tests test.wxml ast 1`] = `
+Object {
+  "inputs": Array [
+    Object {
+      "css": "font-size: 10rpx; color: red;",
+      "file": "/test.wxml",
+      "hasBOM": false,
+    },
+    Object {
+      "css": "font-size: 10rpx; color: {{ color }};",
+      "file": "/test.wxml",
+      "hasBOM": false,
+    },
+    Object {
+      "css": "font-weight: bold; font-size: {{ fontSize }}rpx; color: {{ color }}; background-image: url('{{ backgroundColor }}');",
+      "file": "/test.wxml",
+      "hasBOM": false,
+    },
+    Object {
+      "css": "<wxs src=\\"./foo.wxs\\"></wxs>
+<wxs module=\\"bar\\">
+  var x = 1
+  module.exports = { x: x }
+</wxs>
+<wxs module=\\"baz\\">
+  var style = \\"color: red\\"
+  var tpl = '<view style=\\"color: blue;\\"></view>'
+</wxs>
+<view>
+  <text style=\\"font-size: 10rpx; color: red;\\"></text>
+  <view style=\\"{{ style }}\\"></view>
+  <view style=\\"font-size: 10rpx; color: {{ color }};\\"></view>
+  <view style=\\"font-weight: bold; font-size: {{ fontSize }}rpx; color: {{ color }}; background-image: url('{{ backgroundColor }}');\\"></view>
+</view>",
+      "file": "/test.wxml",
+      "hasBOM": false,
+    },
+  ],
+  "nodes": Array [
+    Object {
+      "document": "$document",
+      "indexes": Object {},
+      "lastEach": 1,
+      "nodes": Array [
+        Object {
+          "prop": "font-size",
+          "raws": Object {
+            "before": "",
+            "between": ": ",
+          },
+          "source": Object {
+            "end": Object {
+              "column": 32,
+              "line": 11,
+              "offset": 235,
+            },
+            "inputId": 0,
+            "start": Object {
+              "column": 16,
+              "line": 11,
+              "offset": 218,
+            },
+          },
+          "type": "decl",
+          "value": "10rpx",
+        },
+        Object {
+          "prop": "color",
+          "raws": Object {
+            "before": " ",
+            "between": ": ",
+          },
+          "source": Object {
+            "end": Object {
+              "column": 44,
+              "line": 11,
+              "offset": 247,
+            },
+            "inputId": 0,
+            "start": Object {
+              "column": 34,
+              "line": 11,
+              "offset": 236,
+            },
+          },
+          "type": "decl",
+          "value": "red",
+        },
+      ],
+      "raws": Object {
+        "after": "",
+        "codeBefore": "<wxs src=\\"./foo.wxs\\"></wxs>
+<wxs module=\\"bar\\">
+  var x = 1
+  module.exports = { x: x }
+</wxs>
+<wxs module=\\"baz\\">
+  var style = \\"color: red\\"
+  var tpl = '<view style=\\"color: blue;\\"></view>'
+</wxs>
+<view>
+  <text style=\\"",
+        "semicolon": true,
+      },
+      "source": Object {
+        "end": Object {
+          "column": 45,
+          "line": 11,
+          "offset": 247,
+        },
+        "inputId": 0,
+        "start": Object {
+          "column": 16,
+          "line": 11,
+          "offset": 218,
+        },
+      },
+      "type": "root",
+    },
+    Object {
+      "document": "$document",
+      "indexes": Object {},
+      "lastEach": 1,
+      "nodes": Array [
+        Object {
+          "prop": "font-size",
+          "raws": Object {
+            "before": "",
+            "between": ": ",
+          },
+          "source": Object {
+            "end": Object {
+              "column": 32,
+              "line": 13,
+              "offset": 325,
+            },
+            "inputId": 0,
+            "start": Object {
+              "column": 16,
+              "line": 13,
+              "offset": 308,
+            },
+          },
+          "type": "decl",
+          "value": "10rpx",
+        },
+        Object {
+          "prop": "color",
+          "raws": Object {
+            "before": " ",
+            "between": ": ",
+          },
+          "source": Object {
+            "end": Object {
+              "column": 52,
+              "line": 13,
+              "offset": 345,
+            },
+            "inputId": 0,
+            "start": Object {
+              "column": 34,
+              "line": 13,
+              "offset": 326,
+            },
+          },
+          "type": "decl",
+          "value": "{{ color }}",
+        },
+      ],
+      "raws": Object {
+        "after": "",
+        "codeBefore": "\\"></text>
+  <view style=\\"{{ style }}\\"></view>
+  <view style=\\"",
+        "semicolon": true,
+      },
+      "source": Object {
+        "end": Object {
+          "column": 53,
+          "line": 13,
+          "offset": 345,
+        },
+        "inputId": 0,
+        "start": Object {
+          "column": 16,
+          "line": 13,
+          "offset": 308,
+        },
+      },
+      "type": "root",
+    },
+    Object {
+      "document": "$document",
+      "indexes": Object {},
+      "lastEach": 1,
+      "nodes": Array [
+        Object {
+          "prop": "font-weight",
+          "raws": Object {
+            "before": "",
+            "between": ": ",
+          },
+          "source": Object {
+            "end": Object {
+              "column": 33,
+              "line": 14,
+              "offset": 388,
+            },
+            "inputId": 0,
+            "start": Object {
+              "column": 16,
+              "line": 14,
+              "offset": 370,
+            },
+          },
+          "type": "decl",
+          "value": "bold",
+        },
+        Object {
+          "prop": "font-size",
+          "raws": Object {
+            "before": " ",
+            "between": ": ",
+          },
+          "source": Object {
+            "end": Object {
+              "column": 63,
+              "line": 14,
+              "offset": 418,
+            },
+            "inputId": 0,
+            "start": Object {
+              "column": 35,
+              "line": 14,
+              "offset": 389,
+            },
+          },
+          "type": "decl",
+          "value": "{{ fontSize }}rpx",
+        },
+        Object {
+          "prop": "color",
+          "raws": Object {
+            "before": " ",
+            "between": ": ",
+          },
+          "source": Object {
+            "end": Object {
+              "column": 83,
+              "line": 14,
+              "offset": 438,
+            },
+            "inputId": 0,
+            "start": Object {
+              "column": 65,
+              "line": 14,
+              "offset": 419,
+            },
+          },
+          "type": "decl",
+          "value": "{{ color }}",
+        },
+        Object {
+          "prop": "background-image",
+          "raws": Object {
+            "before": " ",
+            "between": ": ",
+          },
+          "source": Object {
+            "end": Object {
+              "column": 131,
+              "line": 14,
+              "offset": 486,
+            },
+            "inputId": 0,
+            "start": Object {
+              "column": 85,
+              "line": 14,
+              "offset": 439,
+            },
+          },
+          "type": "decl",
+          "value": "url('{{ backgroundColor }}')",
+        },
+      ],
+      "raws": Object {
+        "after": "",
+        "codeAfter": "\\"></view>
+</view>",
+        "codeBefore": "\\"></view>
+  <view style=\\"",
+        "semicolon": true,
+      },
+      "source": Object {
+        "end": Object {
+          "column": 132,
+          "line": 14,
+          "offset": 486,
+        },
+        "inputId": 0,
+        "start": Object {
+          "column": 16,
+          "line": 14,
+          "offset": 370,
+        },
+      },
+      "type": "root",
+    },
+  ],
+  "raws": Object {},
+  "source": Object {
+    "end": undefined,
+    "inputId": 0,
+    "start": Object {
+      "column": 1,
+      "line": 1,
+    },
+  },
+  "type": "document",
+}
+`;
+
 exports[`AST tests test2.svelte ast 1`] = `
 Object {
   "inputs": Array [

--- a/test/integration/__snapshots__/stylelint.js.snap
+++ b/test/integration/__snapshots__/stylelint.js.snap
@@ -87,6 +87,18 @@ const buttonPointerEvents = computed(() =>
 "
 `;
 
+exports[`Integration with stylelint stylelint --fix with html test.wxml 1`] = `
+"<wxs module=\\"foo\\">
+  var style = \\"color: red\\"
+  var tpl = '<view style=\\"color: blue;\\"></view>'
+</wxs>
+<view>
+  <text style=\\"font-size: 10rpx; color: red;\\"></text>
+  <view style=\\"{{ style }}\\"></view>
+  <view style=\\"font-size: 10rpx; color: {{ color }};\\"></view>
+</view>"
+`;
+
 exports[`Integration with stylelint stylelint --fix with html test-with-stylus.vue 1`] = `
 "<template>
   <div style=\\"display: flex;\\"/>
@@ -275,6 +287,29 @@ Array [
     "rule": "value-keyword-case",
     "severity": "error",
     "text": "Expected \\"buttonColor\\" to be \\"buttoncolor\\" (value-keyword-case)",
+  },
+]
+`;
+
+exports[`Integration with stylelint stylelint with html test.wxml 1`] = `
+Array [
+  Object {
+    "column": 29,
+    "endColumn": 32,
+    "endLine": 6,
+    "line": 6,
+    "rule": "unit-no-unknown",
+    "severity": "error",
+    "text": "Unexpected unknown unit \\"rpx\\" (unit-no-unknown)",
+  },
+  Object {
+    "column": 29,
+    "endColumn": 32,
+    "endLine": 8,
+    "line": 8,
+    "rule": "unit-no-unknown",
+    "severity": "error",
+    "text": "Unexpected unknown unit \\"rpx\\" (unit-no-unknown)",
   },
 ]
 `;

--- a/test/interpolation.js
+++ b/test/interpolation.js
@@ -129,4 +129,38 @@ describe("template interpolation", () => {
 		expect(root.first).to.have.property("prop", "display");
 		expect(root.first).to.have.property("value", "{ dynamicProperties }");
 	});
+
+	it("WXML", () => {
+		const document = syntax.parse(
+			[
+				'<wxs module="baz">',
+				'\tvar style = "color: red"',
+				"\tvar tpl = '<view style=\"color: blue;\"></view>'",
+				"</wxs>",
+				"<view>",
+				"\t<view style=\"font-weight: bold; font-size: {{ fontSize }}rpx; color: {{ color }}; background-image: url('{{ backgroundColor }}');\"></view>",
+				"</view>",
+			].join("\n"),
+			{
+				from: "app.wxml",
+			},
+		);
+		expect(document.nodes).to.have.lengthOf(1);
+		expect(document.first.source).to.have.property("lang", "custom-template");
+		const root = document.first;
+		expect(root.nodes).to.have.lengthOf(4);
+		root.nodes.forEach((node) => {
+			expect(node).to.have.property("type", "decl");
+		});
+		expect(root.nodes[0]).to.include({ prop: "font-weight", value: "bold" });
+		expect(root.nodes[1]).to.include({
+			prop: "font-size",
+			value: "{{ fontSize }}rpx",
+		});
+		expect(root.nodes[2]).to.include({ prop: "color", value: "{{ color }}" });
+		expect(root.nodes[3]).to.include({
+			prop: "background-image",
+			value: "url('{{ backgroundColor }}')",
+		});
+	});
 });

--- a/test/wxml.js
+++ b/test/wxml.js
@@ -1,0 +1,58 @@
+"use strict";
+
+const expect = require("chai").expect;
+const syntax = require("../");
+
+describe("wxml tests", () => {
+	it("ignore style-like content inside wxs", () => {
+		const document = syntax.parse(
+			[
+				'<wxs module="bar">',
+				"  var tpl = '<view style=\"color: blue;\"></view>'",
+				"</wxs>",
+				'<view style="color: red;"></view>',
+			].join("\n"),
+			{
+				from: "app.wxml",
+			},
+		);
+
+		expect(document.nodes).to.have.lengthOf(1);
+		expect(document.first.source).to.have.property("lang", "css");
+		expect(document.first.nodes).to.have.lengthOf(1);
+		expect(document.first.first).to.have.property("prop", "color");
+		expect(document.first.first).to.have.property("value", "red");
+	});
+
+	it("skip full mustache style value", () => {
+		const document = syntax.parse('<view style="{{ style }}"></view>', {
+			from: "app.wxml",
+		});
+
+		expect(document.nodes).to.have.lengthOf(0);
+	});
+
+	it("parse mixed declarations with mustache", () => {
+		const document = syntax.parse(
+			"<view style=\"font-weight: bold; font-size: {{ fontSize }}rpx; color: {{ color }}; background-image: url('{{ backgroundColor }}');\"></view>",
+			{
+				from: "app.wxml",
+			},
+		);
+
+		expect(document.nodes).to.have.lengthOf(1);
+		const root = document.first;
+		expect(root.source).to.have.property("lang", "custom-template");
+		expect(root.nodes).to.have.lengthOf(4);
+		expect(root.nodes[0]).to.include({ prop: "font-weight", value: "bold" });
+		expect(root.nodes[1]).to.include({
+			prop: "font-size",
+			value: "{{ fontSize }}rpx",
+		});
+		expect(root.nodes[2]).to.include({ prop: "color", value: "{{ color }}" });
+		expect(root.nodes[3]).to.include({
+			prop: "background-image",
+			value: "url('{{ backgroundColor }}')",
+		});
+	});
+});


### PR DESCRIPTION
## Motivation

[WXML](https://developers.weixin.qq.com/miniprogram/en/dev/reference/wxml/) is the HTML-like template syntax for WeChat Mini Programs and is popular in China.

Downstream tools (e.g. Stylelint, PostCSS) need to extract and parse inline `style` attributes from `.wxml` sources. Two WXML-specific cases complicate that:

1. **`<wxs>`** embeds JavaScript (analogous to `<script>`). Literal text such as `style=` inside `<wxs>` must not be tokenized as HTML; otherwise the extractor can emit false positives or choke the HTML parser.
2. **`style="{{ ... }}"`** — when the entire attribute value is a mustache expression, treating it like normal CSS is usually undesirable and can skew parsing.

## Implementation

- **`wxml-tokenizer.js`**: subclass htmlparser2's `Tokenizer` so `<wxs>...</wxs>` uses the same **special raw-text** path as built-in `<script>` / `<style>`, scanning until a matching `</wxs>`.
- **`extract-styles`**: if `from` ends with `.wxml` and the `style` value is only `{{ ... }}` (after trim), do not enqueue it for CSS parsing.
- **Tests** covering `<wxs>` noise, mustache-only `style`, and mixed declarations.

## Example

```
<wxs module="baz">
  var style = "color: red"
  module.exports = { style: style }
</wxs>

<view>
  <text style="font-size: 10rpx; color: red;"></text>
  <view style="{{ style }}"></view>
  <view style="font-size: 10rpx; color: {{ color }};"></view>
  <view style="font-weight: bold; font-size: {{ fontSize }}rpx; color: {{ color }}; background-image: url('{{ backgroundColor }}');"></view>
</view>
```