### PR TITLE
fix(test): Update Stylus code fixtures

### DIFF
--- a/test/integration/__snapshots__/stylelint.js.snap
+++ b/test/integration/__snapshots__/stylelint.js.snap
@@ -95,12 +95,12 @@ exports[`Integration with stylelint stylelint --fix with html test-with-stylus.v
 </script>
 <style lang=\\"stylus\\">
 .add-button 
-  color: red;
+  color red;
 
 
 .todo-list 
-  list-style: none
-  background-color: #eef
+  list-style none
+  background-color #eef
 
   .todo-item--done {
     background-color: #3fb983;

--- a/test/root.js
+++ b/test/root.js
@@ -8,11 +8,11 @@ describe("Root node tests", () => {
 		const html = [
 			'<style lang="stylus">',
 			"a",
-			"  display flex",
+			"  display: flex",
 			".b",
-			"  color red",
+			"  color: red",
 			"  .c",
-			"    color red",
+			"    color: red",
 			"</style>",
 		].join("\n");
 		const document = syntax.parse(html, {


### PR DESCRIPTION
I was going to propose a PR for #160, but I noticed that the tests fail on the latest master (although [they didn't two months ago](https://github.com/ota-meshi/postcss-html/actions/runs/25196388945/job/73877854964)). I bisected the dependency versions (which was an adventure on its own) and have found out that PostCSS v8.5.14 (namely https://github.com/postcss/postcss/pull/2084) introduced this (breaking?) change.

I'll be honest, the fix in PostCSS kinda went over my head 😅 Given how this project's focus is in HTML, I considered this to be an unimportant detail and decided to just update the snapshots.

Let me know what you think :)