### PR TITLE
chore!: drop support for Node.js under 22

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,7 +3,7 @@
 {
 	"name": "Node.js & TypeScript",
 	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
-	"image": "mcr.microsoft.com/devcontainers/typescript-node:1-20-bullseye",
+	"image": "mcr.microsoft.com/devcontainers/typescript-node:1-24-bullseye",
 
 	// Features to add to the dev container. More info: https://containers.dev/features.
 	// "features": {},

--- a/.github/workflows/NodeCI.yml
+++ b/.github/workflows/NodeCI.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
         with:
-          node-version: 16
+          node-version: 24
       - name: Install Packages
         run: npm i
       - name: Lint
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [12.x, 14.x, 16.x]
+        node-version: [22.x, 24.x, 26.x]
     steps:
       - uses: actions/checkout@v6
       - name: Use Node.js ${{ matrix.node-version }}

--- a/lib/html/jsx-like-tokenizer.js
+++ b/lib/html/jsx-like-tokenizer.js
@@ -17,7 +17,7 @@ module.exports = class JsxLikeTokenizer extends htmlparser.Tokenizer {
 				this.cbs.onattribdata(this.sectionStart, this.index);
 				this.sectionStart = -1;
 				this.cbs.onattribend(1 /* QuoteType.Unquoted */, this.index);
-				this.state = 8 /* BeforeAttributeName */;
+				this.state = 8; /* BeforeAttributeName */
 				this.stateBeforeAttributeName(this.buffer.charCodeAt(this.index));
 				return;
 			}

--- a/lib/shared/load-module.js
+++ b/lib/shared/load-module.js
@@ -9,7 +9,6 @@ function loadModule(moduleName) {
 		const m = require("module");
 		const cwd = process.cwd();
 		const relativeTo = path.join(cwd, "__placeholder__.js");
-		// eslint-disable-next-line n/no-unsupported-features/node-builtins -- ignore
 		return m.createRequire(relativeTo)(moduleName);
 	} catch (error) {
 		if (!isModuleNotFoundError(error)) {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   },
   "description": "PostCSS syntax for parsing HTML (and HTML-like)",
   "engines": {
-    "node": "^12 || >=14"
+    "node": "^22 || >=24"
   },
   "main": "./lib/index.js",
   "files": [

--- a/test/__snapshots__/ast.js.snap
+++ b/test/__snapshots__/ast.js.snap
@@ -4,6 +4,28 @@ exports[`AST tests brace.svelte ast 1`] = `
 Object {
   "inputs": Array [
     Object {
+      "css": "<script>
+	let color1 = '#f00';
+	let color2 = '#0f0';
+	let color3 = '#00f';
+	let color4 = '#ff0';
+	let value
+</script>
+<input class:over-100={value > 100} bind:value={value} style=\\"color: {color1}\\">
+<input class:over-100={  ((value > 100) )  } bind:value={value} style=\\"color: {color2}\\">
+<input class={ \`\${(value > 100) ? 'foo' : 'bar'}\`  } style=\\"color: {color3}\\">
+<input class={ {foo: (value > 100) ? 'foo' : 'bar'}.foo  } style=\\"color: {color4}\\">
+
+<style>
+input {
+	color: red;
+}
+</style>
+",
+      "file": "/brace.svelte",
+      "hasBOM": false,
+    },
+    Object {
       "css": "color: {color1}",
       "file": "/brace.svelte",
       "hasBOM": false,
@@ -31,28 +53,6 @@ Object {
       "file": "/brace.svelte",
       "hasBOM": false,
     },
-    Object {
-      "css": "<script>
-	let color1 = '#f00';
-	let color2 = '#0f0';
-	let color3 = '#00f';
-	let color4 = '#ff0';
-	let value
-</script>
-<input class:over-100={value > 100} bind:value={value} style=\\"color: {color1}\\">
-<input class:over-100={  ((value > 100) )  } bind:value={value} style=\\"color: {color2}\\">
-<input class={ \`\${(value > 100) ? 'foo' : 'bar'}\`  } style=\\"color: {color3}\\">
-<input class={ {foo: (value > 100) ? 'foo' : 'bar'}.foo  } style=\\"color: {color4}\\">
-
-<style>
-input {
-	color: red;
-}
-</style>
-",
-      "file": "/brace.svelte",
-      "hasBOM": false,
-    },
   ],
   "nodes": Array [
     Object {
@@ -72,7 +72,7 @@ input {
               "line": 8,
               "offset": 195,
             },
-            "inputId": 0,
+            "inputId": 1,
             "start": Object {
               "column": 63,
               "line": 8,
@@ -97,7 +97,7 @@ input {
       },
       "source": Object {
         "end": undefined,
-        "inputId": 0,
+        "inputId": 1,
         "start": Object {
           "column": 63,
           "line": 8,
@@ -123,7 +123,7 @@ input {
               "line": 9,
               "offset": 284,
             },
-            "inputId": 0,
+            "inputId": 2,
             "start": Object {
               "column": 72,
               "line": 9,
@@ -142,7 +142,7 @@ input {
       },
       "source": Object {
         "end": undefined,
-        "inputId": 0,
+        "inputId": 2,
         "start": Object {
           "column": 72,
           "line": 9,
@@ -168,7 +168,7 @@ input {
               "line": 10,
               "offset": 362,
             },
-            "inputId": 0,
+            "inputId": 3,
             "start": Object {
               "column": 61,
               "line": 10,
@@ -187,7 +187,7 @@ input {
       },
       "source": Object {
         "end": undefined,
-        "inputId": 0,
+        "inputId": 3,
         "start": Object {
           "column": 61,
           "line": 10,
@@ -213,7 +213,7 @@ input {
               "line": 11,
               "offset": 446,
             },
-            "inputId": 0,
+            "inputId": 4,
             "start": Object {
               "column": 67,
               "line": 11,
@@ -232,7 +232,7 @@ input {
       },
       "source": Object {
         "end": undefined,
-        "inputId": 0,
+        "inputId": 4,
         "start": Object {
           "column": 67,
           "line": 11,
@@ -263,7 +263,7 @@ input {
                   "line": 15,
                   "offset": 478,
                 },
-                "inputId": 0,
+                "inputId": 5,
                 "start": Object {
                   "column": 2,
                   "line": 15,
@@ -288,7 +288,7 @@ input {
               "line": 16,
               "offset": 480,
             },
-            "inputId": 0,
+            "inputId": 5,
             "start": Object {
               "column": 1,
               "line": 14,
@@ -315,7 +315,7 @@ input {
           "line": 17,
           "offset": 481,
         },
-        "inputId": 0,
+        "inputId": 5,
         "start": Object {
           "column": 1,
           "line": 14,
@@ -342,11 +342,6 @@ exports[`AST tests complex.astro ast 1`] = `
 Object {
   "inputs": Array [
     Object {
-      "css": "color: #00;",
-      "file": "/complex.astro",
-      "hasBOM": false,
-    },
-    Object {
       "css": "---
 let value, input, style, bar
 const foo = 100 <input &&( style=\\"color: #ff;\\" )&& bar > 42
@@ -354,6 +349,11 @@ const foo = 100 <input &&( style=\\"color: #ff;\\" )&& bar > 42
 
 <input class={\`\${value > 100 ? 'over-100' : ''}\`} style=\\"color: #00;\\" />
 ",
+      "file": "/complex.astro",
+      "hasBOM": false,
+    },
+    Object {
+      "css": "color: #00;",
       "file": "/complex.astro",
       "hasBOM": false,
     },
@@ -376,7 +376,7 @@ const foo = 100 <input &&( style=\\"color: #ff;\\" )&& bar > 42
               "line": 6,
               "offset": 166,
             },
-            "inputId": 0,
+            "inputId": 1,
             "start": Object {
               "column": 58,
               "line": 6,
@@ -405,7 +405,7 @@ const foo = 100 <input &&( style=\\"color: #ff;\\" )&& bar > 42
           "line": 6,
           "offset": 166,
         },
-        "inputId": 0,
+        "inputId": 1,
         "start": Object {
           "column": 58,
           "line": 6,
@@ -432,19 +432,19 @@ exports[`AST tests empty-tags.html ast 1`] = `
 Object {
   "inputs": Array [
     Object {
-      "css": "",
-      "file": "/empty-tags.html",
-      "hasBOM": false,
-    },
-    Object {
-      "css": "",
-      "file": "/empty-tags.html",
-      "hasBOM": false,
-    },
-    Object {
       "css": "<style></style>
 <style></style>
 ",
+      "file": "/empty-tags.html",
+      "hasBOM": false,
+    },
+    Object {
+      "css": "",
+      "file": "/empty-tags.html",
+      "hasBOM": false,
+    },
+    Object {
+      "css": "",
       "file": "/empty-tags.html",
       "hasBOM": false,
     },
@@ -465,7 +465,7 @@ Object {
           "line": 1,
           "offset": 7,
         },
-        "inputId": 0,
+        "inputId": 1,
         "start": Object {
           "column": 8,
           "line": 1,
@@ -492,7 +492,7 @@ Object {
           "line": 2,
           "offset": 23,
         },
-        "inputId": 0,
+        "inputId": 2,
         "start": Object {
           "column": 8,
           "line": 2,
@@ -519,14 +519,6 @@ exports[`AST tests frontmatter.astro ast 1`] = `
 Object {
   "inputs": Array [
     Object {
-      "css": "	input {
-		color: red;
-	}
-",
-      "file": "/frontmatter.astro",
-      "hasBOM": false,
-    },
-    Object {
       "css": "
 ---
 let color = '#f00';
@@ -539,6 +531,14 @@ const foo = '<input style=\\"color: blue;\\">'
 		color: red;
 	}
 </style>
+",
+      "file": "/frontmatter.astro",
+      "hasBOM": false,
+    },
+    Object {
+      "css": "	input {
+		color: red;
+	}
 ",
       "file": "/frontmatter.astro",
       "hasBOM": false,
@@ -567,7 +567,7 @@ const foo = '<input style=\\"color: blue;\\">'
                   "line": 10,
                   "offset": 113,
                 },
-                "inputId": 0,
+                "inputId": 1,
                 "start": Object {
                   "column": 3,
                   "line": 10,
@@ -592,7 +592,7 @@ const foo = '<input style=\\"color: blue;\\">'
               "line": 11,
               "offset": 116,
             },
-            "inputId": 0,
+            "inputId": 1,
             "start": Object {
               "column": 2,
               "line": 9,
@@ -624,7 +624,7 @@ const foo = '<input style=\\"color: blue;\\">'
           "line": 12,
           "offset": 117,
         },
-        "inputId": 0,
+        "inputId": 1,
         "start": Object {
           "column": 1,
           "line": 9,
@@ -650,47 +650,6 @@ const foo = '<input style=\\"color: blue;\\">'
 exports[`AST tests ignore-comment.vue ast 1`] = `
 Object {
   "inputs": Array [
-    Object {
-      "css": "color: blue",
-      "file": "/ignore-comment.vue",
-      "hasBOM": false,
-    },
-    Object {
-      "css": "color: green",
-      "file": "/ignore-comment.vue",
-      "hasBOM": false,
-    },
-    Object {
-      "css": "color: white",
-      "file": "/ignore-comment.vue",
-      "hasBOM": false,
-    },
-    Object {
-      "css": "color: brack",
-      "file": "/ignore-comment.vue",
-      "hasBOM": false,
-    },
-    Object {
-      "css": "color: yellow",
-      "file": "/ignore-comment.vue",
-      "hasBOM": false,
-    },
-    Object {
-      "css": ".b {
-  color: red;
-}
-",
-      "file": "/ignore-comment.vue",
-      "hasBOM": false,
-    },
-    Object {
-      "css": ".c {
-  color: red;
-}
-",
-      "file": "/ignore-comment.vue",
-      "hasBOM": false,
-    },
     Object {
       "css": "<template>
   <div>
@@ -742,6 +701,47 @@ a {
       "file": "/ignore-comment.vue",
       "hasBOM": false,
     },
+    Object {
+      "css": "color: blue",
+      "file": "/ignore-comment.vue",
+      "hasBOM": false,
+    },
+    Object {
+      "css": "color: green",
+      "file": "/ignore-comment.vue",
+      "hasBOM": false,
+    },
+    Object {
+      "css": "color: white",
+      "file": "/ignore-comment.vue",
+      "hasBOM": false,
+    },
+    Object {
+      "css": "color: brack",
+      "file": "/ignore-comment.vue",
+      "hasBOM": false,
+    },
+    Object {
+      "css": "color: yellow",
+      "file": "/ignore-comment.vue",
+      "hasBOM": false,
+    },
+    Object {
+      "css": ".b {
+  color: red;
+}
+",
+      "file": "/ignore-comment.vue",
+      "hasBOM": false,
+    },
+    Object {
+      "css": ".c {
+  color: red;
+}
+",
+      "file": "/ignore-comment.vue",
+      "hasBOM": false,
+    },
   ],
   "nodes": Array [
     Object {
@@ -761,7 +761,7 @@ a {
               "line": 5,
               "offset": 103,
             },
-            "inputId": 0,
+            "inputId": 1,
             "start": Object {
               "column": 19,
               "line": 5,
@@ -787,7 +787,7 @@ a {
           "line": 5,
           "offset": 103,
         },
-        "inputId": 0,
+        "inputId": 1,
         "start": Object {
           "column": 19,
           "line": 5,
@@ -813,7 +813,7 @@ a {
               "line": 10,
               "offset": 196,
             },
-            "inputId": 0,
+            "inputId": 2,
             "start": Object {
               "column": 17,
               "line": 10,
@@ -840,7 +840,7 @@ a {
           "line": 10,
           "offset": 196,
         },
-        "inputId": 0,
+        "inputId": 2,
         "start": Object {
           "column": 17,
           "line": 10,
@@ -866,7 +866,7 @@ a {
               "line": 14,
               "offset": 280,
             },
-            "inputId": 0,
+            "inputId": 3,
             "start": Object {
               "column": 17,
               "line": 14,
@@ -892,7 +892,7 @@ a {
           "line": 14,
           "offset": 280,
         },
-        "inputId": 0,
+        "inputId": 3,
         "start": Object {
           "column": 17,
           "line": 14,
@@ -918,7 +918,7 @@ a {
               "line": 17,
               "offset": 359,
             },
-            "inputId": 0,
+            "inputId": 4,
             "start": Object {
               "column": 17,
               "line": 17,
@@ -943,7 +943,7 @@ a {
           "line": 17,
           "offset": 359,
         },
-        "inputId": 0,
+        "inputId": 4,
         "start": Object {
           "column": 17,
           "line": 17,
@@ -969,7 +969,7 @@ a {
               "line": 20,
               "offset": 438,
             },
-            "inputId": 0,
+            "inputId": 5,
             "start": Object {
               "column": 17,
               "line": 20,
@@ -994,7 +994,7 @@ a {
           "line": 20,
           "offset": 438,
         },
-        "inputId": 0,
+        "inputId": 5,
         "start": Object {
           "column": 17,
           "line": 20,
@@ -1025,7 +1025,7 @@ a {
                   "line": 34,
                   "offset": 560,
                 },
-                "inputId": 0,
+                "inputId": 6,
                 "start": Object {
                   "column": 3,
                   "line": 34,
@@ -1050,7 +1050,7 @@ a {
               "line": 35,
               "offset": 562,
             },
-            "inputId": 0,
+            "inputId": 6,
             "start": Object {
               "column": 1,
               "line": 33,
@@ -1085,7 +1085,7 @@ a {
           "line": 36,
           "offset": 563,
         },
-        "inputId": 0,
+        "inputId": 6,
         "start": Object {
           "column": 1,
           "line": 33,
@@ -1116,7 +1116,7 @@ a {
                   "line": 44,
                   "offset": 651,
                 },
-                "inputId": 0,
+                "inputId": 7,
                 "start": Object {
                   "column": 3,
                   "line": 44,
@@ -1141,7 +1141,7 @@ a {
               "line": 45,
               "offset": 653,
             },
-            "inputId": 0,
+            "inputId": 7,
             "start": Object {
               "column": 1,
               "line": 43,
@@ -1172,7 +1172,7 @@ a {
           "line": 46,
           "offset": 654,
         },
-        "inputId": 0,
+        "inputId": 7,
         "start": Object {
           "column": 1,
           "line": 43,
@@ -1199,16 +1199,6 @@ exports[`AST tests lang-postcss.vue ast 1`] = `
 Object {
   "inputs": Array [
     Object {
-      "css": "a {
-a {
-color: red
-}
-}
-",
-      "file": "/lang-postcss.vue",
-      "hasBOM": false,
-    },
-    Object {
       "css": "<template>
 </template>
 <style lang=\\"postcss\\">
@@ -1218,6 +1208,16 @@ color: red
 }
 }
 </style>
+",
+      "file": "/lang-postcss.vue",
+      "hasBOM": false,
+    },
+    Object {
+      "css": "a {
+a {
+color: red
+}
+}
 ",
       "file": "/lang-postcss.vue",
       "hasBOM": false,
@@ -1250,7 +1250,7 @@ color: red
                       "line": 6,
                       "offset": 64,
                     },
-                    "inputId": 0,
+                    "inputId": 1,
                     "start": Object {
                       "column": 1,
                       "line": 6,
@@ -1276,7 +1276,7 @@ color: red
                   "line": 7,
                   "offset": 66,
                 },
-                "inputId": 0,
+                "inputId": 1,
                 "start": Object {
                   "column": 1,
                   "line": 5,
@@ -1300,7 +1300,7 @@ color: red
               "line": 8,
               "offset": 68,
             },
-            "inputId": 0,
+            "inputId": 1,
             "start": Object {
               "column": 1,
               "line": 4,
@@ -1327,7 +1327,7 @@ color: red
           "line": 9,
           "offset": 69,
         },
-        "inputId": 0,
+        "inputId": 1,
         "start": Object {
           "column": 1,
           "line": 4,
@@ -1354,24 +1354,6 @@ exports[`AST tests test.astro ast 1`] = `
 Object {
   "inputs": Array [
     Object {
-      "css": "color: red;",
-      "file": "/test.astro",
-      "hasBOM": false,
-    },
-    Object {
-      "css": "color: green;",
-      "file": "/test.astro",
-      "hasBOM": false,
-    },
-    Object {
-      "css": "input {
-	color: red;
-}
-",
-      "file": "/test.astro",
-      "hasBOM": false,
-    },
-    Object {
       "css": "---
 let color = '#f00';
 let value
@@ -1386,6 +1368,24 @@ input {
 	color: red;
 }
 </style>
+",
+      "file": "/test.astro",
+      "hasBOM": false,
+    },
+    Object {
+      "css": "color: red;",
+      "file": "/test.astro",
+      "hasBOM": false,
+    },
+    Object {
+      "css": "color: green;",
+      "file": "/test.astro",
+      "hasBOM": false,
+    },
+    Object {
+      "css": "input {
+	color: red;
+}
 ",
       "file": "/test.astro",
       "hasBOM": false,
@@ -1409,7 +1409,7 @@ input {
               "line": 7,
               "offset": 145,
             },
-            "inputId": 0,
+            "inputId": 1,
             "start": Object {
               "column": 53,
               "line": 7,
@@ -1437,7 +1437,7 @@ const foo = '<input style=\\"color: blue;\\">'
           "line": 7,
           "offset": 145,
         },
-        "inputId": 0,
+        "inputId": 1,
         "start": Object {
           "column": 53,
           "line": 7,
@@ -1463,7 +1463,7 @@ const foo = '<input style=\\"color: blue;\\">'
               "line": 8,
               "offset": 224,
             },
-            "inputId": 0,
+            "inputId": 2,
             "start": Object {
               "column": 62,
               "line": 8,
@@ -1486,7 +1486,7 @@ const foo = '<input style=\\"color: blue;\\">'
           "line": 8,
           "offset": 224,
         },
-        "inputId": 0,
+        "inputId": 2,
         "start": Object {
           "column": 62,
           "line": 8,
@@ -1517,7 +1517,7 @@ const foo = '<input style=\\"color: blue;\\">'
                   "line": 12,
                   "offset": 258,
                 },
-                "inputId": 0,
+                "inputId": 3,
                 "start": Object {
                   "column": 2,
                   "line": 12,
@@ -1542,7 +1542,7 @@ const foo = '<input style=\\"color: blue;\\">'
               "line": 13,
               "offset": 260,
             },
-            "inputId": 0,
+            "inputId": 3,
             "start": Object {
               "column": 1,
               "line": 11,
@@ -1569,7 +1569,7 @@ const foo = '<input style=\\"color: blue;\\">'
           "line": 14,
           "offset": 261,
         },
-        "inputId": 0,
+        "inputId": 3,
         "start": Object {
           "column": 1,
           "line": 11,
@@ -1596,19 +1596,6 @@ exports[`AST tests test.html ast 1`] = `
 Object {
   "inputs": Array [
     Object {
-      "css": "			a {
-				display: flex;
-			}
-",
-      "file": "/test.html",
-      "hasBOM": false,
-    },
-    Object {
-      "css": "font-family: serif serif",
-      "file": "/test.html",
-      "hasBOM": false,
-    },
-    Object {
       "css": "<!DOCTYPE html>
 <html>
 	<head>
@@ -1623,6 +1610,19 @@ Object {
 	</body>
 </html>
 ",
+      "file": "/test.html",
+      "hasBOM": false,
+    },
+    Object {
+      "css": "			a {
+				display: flex;
+			}
+",
+      "file": "/test.html",
+      "hasBOM": false,
+    },
+    Object {
+      "css": "font-family: serif serif",
       "file": "/test.html",
       "hasBOM": false,
     },
@@ -1650,7 +1650,7 @@ Object {
                   "line": 6,
                   "offset": 82,
                 },
-                "inputId": 0,
+                "inputId": 1,
                 "start": Object {
                   "column": 5,
                   "line": 6,
@@ -1675,7 +1675,7 @@ Object {
               "line": 7,
               "offset": 87,
             },
-            "inputId": 0,
+            "inputId": 1,
             "start": Object {
               "column": 4,
               "line": 5,
@@ -1701,7 +1701,7 @@ Object {
           "line": 8,
           "offset": 88,
         },
-        "inputId": 0,
+        "inputId": 1,
         "start": Object {
           "column": 1,
           "line": 5,
@@ -1727,7 +1727,7 @@ Object {
               "line": 11,
               "offset": 154,
             },
-            "inputId": 0,
+            "inputId": 2,
             "start": Object {
               "column": 15,
               "line": 11,
@@ -1756,7 +1756,7 @@ Object {
           "line": 11,
           "offset": 154,
         },
-        "inputId": 0,
+        "inputId": 2,
         "start": Object {
           "column": 15,
           "line": 11,
@@ -1783,16 +1783,6 @@ exports[`AST tests test.svelte ast 1`] = `
 Object {
   "inputs": Array [
     Object {
-      "css": "color: {color}; --opacity: {bgOpacity};",
-      "file": "/test.svelte",
-      "hasBOM": false,
-    },
-    Object {
-      "css": "color: {color}",
-      "file": "/test.svelte",
-      "hasBOM": false,
-    },
-    Object {
       "css": "<script>
 	let bgOpacity = 0.5;
 	$: color = bgOpacity < 0.6 ? '#000' : '#fff';
@@ -1800,6 +1790,16 @@ Object {
 <p style=\\"color: {color}; --opacity: {bgOpacity};\\">This is a paragraph.</p>
 <p style=\\"color: {color}\\">This is a paragraph.</p>
 ",
+      "file": "/test.svelte",
+      "hasBOM": false,
+    },
+    Object {
+      "css": "color: {color}; --opacity: {bgOpacity};",
+      "file": "/test.svelte",
+      "hasBOM": false,
+    },
+    Object {
+      "css": "color: {color}",
       "file": "/test.svelte",
       "hasBOM": false,
     },
@@ -1822,7 +1822,7 @@ Object {
               "line": 5,
               "offset": 113,
             },
-            "inputId": 0,
+            "inputId": 1,
             "start": Object {
               "column": 11,
               "line": 5,
@@ -1844,7 +1844,7 @@ Object {
               "line": 5,
               "offset": 137,
             },
-            "inputId": 0,
+            "inputId": 1,
             "start": Object {
               "column": 27,
               "line": 5,
@@ -1866,7 +1866,7 @@ Object {
       },
       "source": Object {
         "end": undefined,
-        "inputId": 0,
+        "inputId": 1,
         "start": Object {
           "column": 11,
           "line": 5,
@@ -1892,7 +1892,7 @@ Object {
               "line": 6,
               "offset": 188,
             },
-            "inputId": 0,
+            "inputId": 2,
             "start": Object {
               "column": 11,
               "line": 6,
@@ -1913,7 +1913,7 @@ Object {
       },
       "source": Object {
         "end": undefined,
-        "inputId": 0,
+        "inputId": 2,
         "start": Object {
           "column": 11,
           "line": 6,
@@ -1939,25 +1939,6 @@ Object {
 exports[`AST tests test.vue ast 1`] = `
 Object {
   "inputs": Array [
-    Object {
-      "css": ".add-button {
-  color: v-bind(buttonColor);
-  pointer-events: v-bind(\\"inputValue ? 'initial' : 'none'\\");
-}
-.todo-list {
-  list-style: none;
-}
-.todo-item {
-  background-color: #eef;
-}
-.todo-item--done {
-  background-color: #3fb983;
-  color: #fff;
-}
-",
-      "file": "/test.vue",
-      "hasBOM": false,
-    },
     Object {
       "css": "<template>
   <input v-model=\\"inputValue\\" />
@@ -2013,6 +1994,25 @@ const buttonPointerEvents = computed(() =>
       "file": "/test.vue",
       "hasBOM": false,
     },
+    Object {
+      "css": ".add-button {
+  color: v-bind(buttonColor);
+  pointer-events: v-bind(\\"inputValue ? 'initial' : 'none'\\");
+}
+.todo-list {
+  list-style: none;
+}
+.todo-item {
+  background-color: #eef;
+}
+.todo-item--done {
+  background-color: #3fb983;
+  color: #fff;
+}
+",
+      "file": "/test.vue",
+      "hasBOM": false,
+    },
   ],
   "nodes": Array [
     Object {
@@ -2037,7 +2037,7 @@ const buttonPointerEvents = computed(() =>
                   "line": 37,
                   "offset": 902,
                 },
-                "inputId": 0,
+                "inputId": 1,
                 "start": Object {
                   "column": 3,
                   "line": 37,
@@ -2060,7 +2060,7 @@ const buttonPointerEvents = computed(() =>
                   "line": 38,
                   "offset": 963,
                 },
-                "inputId": 0,
+                "inputId": 1,
                 "start": Object {
                   "column": 3,
                   "line": 38,
@@ -2085,7 +2085,7 @@ const buttonPointerEvents = computed(() =>
               "line": 39,
               "offset": 965,
             },
-            "inputId": 0,
+            "inputId": 1,
             "start": Object {
               "column": 1,
               "line": 36,
@@ -2111,7 +2111,7 @@ const buttonPointerEvents = computed(() =>
                   "line": 41,
                   "offset": 998,
                 },
-                "inputId": 0,
+                "inputId": 1,
                 "start": Object {
                   "column": 3,
                   "line": 41,
@@ -2137,7 +2137,7 @@ const buttonPointerEvents = computed(() =>
               "line": 42,
               "offset": 1000,
             },
-            "inputId": 0,
+            "inputId": 1,
             "start": Object {
               "column": 1,
               "line": 40,
@@ -2163,7 +2163,7 @@ const buttonPointerEvents = computed(() =>
                   "line": 44,
                   "offset": 1039,
                 },
-                "inputId": 0,
+                "inputId": 1,
                 "start": Object {
                   "column": 3,
                   "line": 44,
@@ -2189,7 +2189,7 @@ const buttonPointerEvents = computed(() =>
               "line": 45,
               "offset": 1041,
             },
-            "inputId": 0,
+            "inputId": 1,
             "start": Object {
               "column": 1,
               "line": 43,
@@ -2215,7 +2215,7 @@ const buttonPointerEvents = computed(() =>
                   "line": 47,
                   "offset": 1089,
                 },
-                "inputId": 0,
+                "inputId": 1,
                 "start": Object {
                   "column": 3,
                   "line": 47,
@@ -2238,7 +2238,7 @@ const buttonPointerEvents = computed(() =>
                   "line": 48,
                   "offset": 1104,
                 },
-                "inputId": 0,
+                "inputId": 1,
                 "start": Object {
                   "column": 3,
                   "line": 48,
@@ -2264,7 +2264,7 @@ const buttonPointerEvents = computed(() =>
               "line": 49,
               "offset": 1106,
             },
-            "inputId": 0,
+            "inputId": 1,
             "start": Object {
               "column": 1,
               "line": 46,
@@ -2323,7 +2323,7 @@ const buttonPointerEvents = computed(() =>
           "line": 50,
           "offset": 1107,
         },
-        "inputId": 0,
+        "inputId": 1,
         "start": Object {
           "column": 1,
           "line": 36,
@@ -2350,11 +2350,6 @@ exports[`AST tests test2.svelte ast 1`] = `
 Object {
   "inputs": Array [
     Object {
-      "css": "color: {color}; {styleOpacity}",
-      "file": "/test2.svelte",
-      "hasBOM": false,
-    },
-    Object {
       "css": "<script>
 	let bgOpacity = 0.5;
 	$: color = bgOpacity < 0.6 ? '#000' : '#fff';
@@ -2362,6 +2357,11 @@ Object {
 </script>
 <p style=\\"color: {color}; {styleOpacity}\\">This is a paragraph.</p>
 ",
+      "file": "/test2.svelte",
+      "hasBOM": false,
+    },
+    Object {
+      "css": "color: {color}; {styleOpacity}",
       "file": "/test2.svelte",
       "hasBOM": false,
     },
@@ -2384,7 +2384,7 @@ Object {
               "line": 6,
               "offset": 159,
             },
-            "inputId": 0,
+            "inputId": 1,
             "start": Object {
               "column": 11,
               "line": 6,
@@ -2409,7 +2409,7 @@ Object {
       },
       "source": Object {
         "end": undefined,
-        "inputId": 0,
+        "inputId": 1,
         "start": Object {
           "column": 11,
           "line": 6,
@@ -2436,12 +2436,6 @@ exports[`AST tests unknown-lang.vue ast 1`] = `
 Object {
   "inputs": Array [
     Object {
-      "css": "a {}
-",
-      "file": "/unknown-lang.vue",
-      "hasBOM": false,
-    },
-    Object {
       "css": "<template>
 </template>
 <script setup>
@@ -2452,6 +2446,12 @@ unknown////
 <style lang=\\"css\\">
 a {}
 </style>
+",
+      "file": "/unknown-lang.vue",
+      "hasBOM": false,
+    },
+    Object {
+      "css": "a {}
 ",
       "file": "/unknown-lang.vue",
       "hasBOM": false,
@@ -2479,7 +2479,7 @@ a {}
               "line": 9,
               "offset": 115,
             },
-            "inputId": 0,
+            "inputId": 1,
             "start": Object {
               "column": 1,
               "line": 9,
@@ -2511,7 +2511,7 @@ unknown////
           "line": 10,
           "offset": 116,
         },
-        "inputId": 0,
+        "inputId": 1,
         "start": Object {
           "column": 1,
           "line": 9,


### PR DESCRIPTION
Closes #160

I had to update the test snapshots, as some DOM nodes seem to have shifted around after some dependency updates